### PR TITLE
Facebook Auth bug fix

### DIFF
--- a/Auth/Auth.php
+++ b/Auth/Auth.php
@@ -137,7 +137,7 @@ class Auth extends Component
     protected function authenticateOrCreateFacebookUser($facebookUser)
     {
         $pupRedirect = $this->di->get('config')->pup->redirect;
-        $email       = isset($facebookUser['email']) ? $facebookUser['email'] : 'a@a.com';
+        $email       = isset($facebookUser['email']) ? $facebookUser['email'] : "{$facebookUser['id']}@facebook.com";
         $user        = User::findFirst(" email='$email' OR facebook_id='".$facebookUser['id']."' ");
 
         if ($user) {


### PR DESCRIPTION
This needs to be done or the query needs to be fixed in order to prevent Facebook users to gain access to another user's data if they did not provide the "email" permission.